### PR TITLE
Fix ssh-key access issue

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -80,6 +80,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
+    fsGroup: {{ .Values.gid }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}


### PR DESCRIPTION
This change allows `dags.gitSync.containerName` to read ssh-key from file system.
Similar to this https://github.com/varunvora/airflow/blob/ce0e6280d2ea39838e9f0617625cd07a757c3461/chart/templates/scheduler/scheduler-deployment.yaml#L92
It solves https://github.com/apache/airflow/issues/13680 issue for private repositories.